### PR TITLE
#169447163 return user info when user sign up or log in

### DIFF
--- a/Server/controllers/userController.js
+++ b/Server/controllers/userController.js
@@ -27,7 +27,11 @@ export default class UserController {
       };
       if (users.length > 0) newUser.user_id = users[users.length - 1].user_id + 1;
       users.push(newUser);
-      send.successful(201, 'user created successfully', { token: jwt.sign({ user_id: newUser.user_id }, process.env.JWT_KEY) });
+      const { ...sendUser } = newUser;
+      delete sendUser.password;
+      send.successful(201, 'user created successfully', {
+        token: jwt.sign({ user_id: newUser.user_id }, process.env.JWT_KEY), user: sendUser
+      });
       return send.send(res);
     } catch (err) {
       send.error(500, err);
@@ -50,7 +54,11 @@ export default class UserController {
     }
     try {
       if (!await bcrypt.compare(password, user.password)) throw new Error('incorrect email or password');
-      send.successful(200, 'User logged in successfully', { token: jwt.sign({ user_id: user.user_id }, process.env.JWT_KEY) });
+      const { ...sendUser } = user;
+      delete sendUser.password;
+      send.successful(200, 'User logged in successfully', {
+        token: jwt.sign({ user_id: user.user_id }, process.env.JWT_KEY), user: sendUser
+      });
       return send.send(res);
     } catch (err) {
       if (err.message === 'incorrect email or password') {

--- a/Server/tests/a-user.test.js
+++ b/Server/tests/a-user.test.js
@@ -68,7 +68,7 @@ describe('users can signup', () => {
         done();
       });
   });
-  it('it should sign up new users(first on the server', (done) => {
+  it('it should sign up new users(first on the server)', (done) => {
     const newUser = {
       firstName: 'John',
       lastName: 'Ishimwe',
@@ -82,6 +82,12 @@ describe('users can signup', () => {
       .end((err, res) => {
         expect(res.status).to.equal(201);
         expect(res.body).to.have.property('data');
+        expect(res.body.data).to.have.property('user');
+        expect(res.body.data.user).to.have.property('user_id');
+        expect(res.body.data.user).to.have.property('firstName');
+        expect(res.body.data.user).to.have.property('lastName');
+        expect(res.body.data.user).to.have.property('email');
+        expect(res.body.data.user).to.not.have.property('password');
         done();
       });
   });
@@ -134,6 +140,12 @@ describe('users can signin', () => {
         expect(res.status).to.equal(200);
         expect(res.body).to.have.property('data');
         expect(res.body.data).to.have.property('token');
+        expect(res.body.data).to.have.property('user');
+        expect(res.body.data.user).to.have.property('user_id');
+        expect(res.body.data.user).to.have.property('firstName');
+        expect(res.body.data.user).to.have.property('lastName');
+        expect(res.body.data.user).to.have.property('email');
+        expect(res.body.data.user).to.not.have.property('password');
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
this `pr` adds user information to the response object when user sign up or login
#### Description of Task to be completed?
- update the sign up and login response to send user info
- removed password from the info sent
- update the user test
#### How should this be manually tested?
- clone this repo
- run `npm install`
- run `npm run dev`
- send a signup or login request(check the readme for endpoints)
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#169447163
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A