### PR TITLE
#169449017 user is able to get an entry using a slug

### DIFF
--- a/Server/controllers/entryController.js
+++ b/Server/controllers/entryController.js
@@ -1,4 +1,5 @@
 import Send from '../helpers/send';
+import slugStr from '../helpers/slug';
 import entries from '../data/entryData';
 import EntryValidator from '../helpers/entryValidators';
 
@@ -10,12 +11,14 @@ export default class EntryController {
       send.error(400, error);
       return send.send(res);
     }
+    const slug = slugStr(req.body.title);
     const entry = {
       id: 1,
-      title: req.body.title,
       createdOn: new Date().toDateString(),
-      user_id: req.user.user_id,
-      description: req.body.description
+      slug,
+      title: req.body.title,
+      description: req.body.description,
+      user_id: req.user.user_id
     };
     if (entries.length > 0) {
       entry.id = entries[entries.length - 1].id + 1;
@@ -63,5 +66,18 @@ export default class EntryController {
     const { entry } = req;
     send.successful(200, null, entry);
     return send.send(res);
+  }
+
+  static getBySlug(req, res) {
+    const send = new Send();
+    const { slug } = req.params;
+    const userEntries = entries.filter((el) => el.user_id === req.user.user_id);
+    const entry = userEntries.find((el) => el.slug === slug);
+    if (!entry) {
+      send.error(404, new Error(`entry with slug equal to ${slug}. not found`));
+      return send.send(res);
+    }
+    send.successful(200, null, entry);
+    send.send(res);
   }
 }

--- a/Server/helpers/slug.js
+++ b/Server/helpers/slug.js
@@ -1,0 +1,7 @@
+import slugify from 'slugify';
+import uniqueSlug from 'unique-slug';
+
+const slugStr = (string) => {
+  return `${slugify(string)}-${uniqueSlug()}`;
+};
+export default slugStr;

--- a/Server/routes/entryRoute.js
+++ b/Server/routes/entryRoute.js
@@ -16,5 +16,8 @@ router
   .patch(EntryController.updateEntry)
   .delete(EntryController.deleteEntry)
   .get(EntryController.getAnEntry);
+router
+  .route('/title/:slug')
+  .get(EntryController.getBySlug);
 
 export default router;

--- a/Server/tests/entry.test.js
+++ b/Server/tests/entry.test.js
@@ -11,6 +11,7 @@ dotenv.config();
 describe('entry endpoints testing', () => {
   describe('when the user has signed up and given a valid token', () => {
     let token;
+    let slug;
     before((done) => {
       const loggedUser = {
         email: 'john45@gmail.com',
@@ -57,11 +58,13 @@ describe('entry endpoints testing', () => {
         .set('token', `Bearer ${token}`)
         .send(entry)
         .end((err, res) => {
+          slug = res.body.data.slug;
           expect(res.status).to.equal(201);
           expect(res.body.data).to.include({
             title: entry.title,
             description: entry.description
           });
+          expect(res.body.data).to.have.property('slug');
           expect(res.body.data.id).to.equal(2);
           done();
         });
@@ -247,6 +250,32 @@ describe('entry endpoints testing', () => {
         .set('token', `Bearer ${token}`)
         .end((err, res) => {
           expect(res.status).to.equal(400);
+          done();
+        });
+    });
+    it('should get an entry when a title slug is given', (done) => {
+      chai
+        .request(app)
+        .get(`/api/v1/entries/title/${slug}`)
+        .set('token', `Bearer ${token}`)
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.property('data');
+          expect(res.body.data).to.have.property('title');
+          expect(res.body.data).to.have.property('description');
+          expect(res.body.data).to.have.property('createdOn');
+          expect(res.body.data).to.have.property('slug');
+          expect(res.body.data.slug).to.equal(slug);
+          done();
+        });
+    });
+    it('should get an entry when a title slug is given', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/entries/title/day-dfewdes')
+        .set('token', `Bearer ${token}`)
+        .end((err, res) => {
+          expect(res.status).to.equal(404);
           done();
         });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3804,8 +3804,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "inflight": {
       "version": "1.0.6",
@@ -6000,6 +5999,11 @@
         }
       }
     },
+    "slugify": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.5.tgz",
+      "integrity": "sha512-5VCnH7aS13b0UqWOs7Ef3E5rkhFe8Od+cp7wybFv5mv/sYSRkucZlJX0bamAJky7b2TTtGvrJBWVdpdEicsSrA=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -6709,6 +6713,14 @@
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "requires": {
+        "imurmurhash": "^0.1.4"
       }
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "dotenv": "^8.1.0",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
-    "morgan": "^1.9.1"
+    "morgan": "^1.9.1",
+    "slugify": "^1.3.5",
+    "unique-slug": "^2.0.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.2",


### PR DESCRIPTION
#### What does this PR do? 
this `pr` adds the slug functionality to the app where user can get a entry by a slug
#### Description of Task to be completed?
- added the slug.js to return the slug from the title
- added another entry route to handle get request with a slug
- added test for the slug route
#### How should this be manually tested?
- clone this repo
- run `npm install`
- run `npm run dev`
- sign up into the app
- then create an entry
- request a get request to **/api/v1/entries/title/:slug**
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#169449017
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A