### PR TITLE
#169474819 user should get a 404 message when he/she has an empty diary

### DIFF
--- a/Server/controllers/entryController.js
+++ b/Server/controllers/entryController.js
@@ -57,6 +57,10 @@ export default class EntryController {
   static getAllEntry(req, res) {
     const send = new Send();
     const userEntries = entries.filter((el) => el.user_id === req.user.user_id);
+    if (userEntries.length < 1) {
+      send.error(404, new Error('your diary is empty, no entries found'));
+      return send.send(res);
+    }
     send.successful(200, null, userEntries);
     return send.send(res);
   }

--- a/Server/tests/entry.test.js
+++ b/Server/tests/entry.test.js
@@ -28,6 +28,15 @@ describe('entry endpoints testing', () => {
       const userId = users[users.length - 1].user_id;
       token = jwt.sign({ user_id: userId }, process.env.JWT_KEY);
     });
+    it('it should get an entry', (done) => {
+      chai.request(app)
+        .get('/api/v1/entries')
+        .set('token', `Bearer ${token}`)
+        .end((err, res) => {
+          expect(res.status).to.equal(404);
+          done();
+        });
+    });
     it('it should create a entry', (done) => {
       const entry = {
         title: 'wow',


### PR DESCRIPTION
#### What does this PR do?
this `pr`  fix a bug where a user with  no entries in his/her diary get an empty array when he/she do a get all entries request
#### Description of Task to be completed?
- fixed the issue of no entry
- added the test of the no entry path
#### How should this be manually tested?
- clone this repo
- run `npm install`
- run `npm run dev`
- sign up in the app using post man
- get all entries before creating one
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#169474819
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A