### PR TITLE
bug(validation error): users are able to get a nice error message

### DIFF
--- a/Server/controllers/entryController.js
+++ b/Server/controllers/entryController.js
@@ -6,11 +6,6 @@ import EntryValidator from '../helpers/entryValidators';
 export default class EntryController {
   static createEntry(req, res) {
     const send = new Send();
-    const { error } = EntryValidator.create(req.body);
-    if (error) {
-      send.error(400, error);
-      return send.send(res);
-    }
     const slug = slugStr(req.body.title);
     const entry = {
       id: 1,
@@ -31,11 +26,6 @@ export default class EntryController {
   static updateEntry(req, res) {
     const send = new Send();
     const { entry } = req;
-    const { error } = EntryValidator.update(req.body);
-    if (error) {
-      send.error(400, error);
-      return send.send(res);
-    }
     if (req.body.title) {
       entry.title = req.body.title;
     }

--- a/Server/helpers/errorString.js
+++ b/Server/helpers/errorString.js
@@ -1,0 +1,10 @@
+const erroraString = (error) => {
+  let newString = error.details[0].message.replace('/', '').replace(/"/g, '');
+  if (error.details[0].type === 'object.missing') {
+    newString = newString.replace('value', 'The request').replace(',', ' or')
+      .replace('[', '').replace('one of', 'a')
+      .replace(']', '');
+  }
+  return newString;
+};
+export default erroraString;

--- a/Server/helpers/send.js
+++ b/Server/helpers/send.js
@@ -13,9 +13,6 @@ export default class Send {
 
   error(statusCode, error) {
     this.statusCode = statusCode;
-    if (error.details) {
-      this.message = error.details[0].message;
-    }
     this.message = error.message;
   }
 

--- a/Server/middleware/entryVal.js
+++ b/Server/middleware/entryVal.js
@@ -1,11 +1,11 @@
-import UserValidator from '../helpers/userValidators';
+import EntryValidator from '../helpers/entryValidators';
 import Send from '../helpers/send';
 import errorString from '../helpers/errorString';
 
 export default class userValidatorMid {
-  static signup(req, res, next) {
+  static create(req, res, next) {
     const send = new Send();
-    const { error } = UserValidator.signup(req.body);
+    const { error } = EntryValidator.create(req.body);
     if (error) {
       const newMessage = errorString(error);
       send.error(400, new Error(newMessage));
@@ -14,9 +14,9 @@ export default class userValidatorMid {
     next();
   }
 
-  static login(req, res, next) {
+  static update(req, res, next) {
     const send = new Send();
-    const { error } = UserValidator.login(req.body);
+    const { error } = EntryValidator.update(req.body);
     if (error) {
       const newMessage = errorString(error);
       send.error(400, new Error(newMessage));

--- a/Server/routes/entryRoute.js
+++ b/Server/routes/entryRoute.js
@@ -2,18 +2,19 @@ import express from 'express';
 import EntryController from '../controllers/entryController';
 import users from '../data/userData';
 import protect from '../middleware/protect';
+import EntryValidatorMiddleware from '../middleware/entryVal';
 import idhandler from '../middleware/idHandler';
 
 const router = express.Router();
 router.use(protect);
 router
   .route('/')
-  .post(EntryController.createEntry)
+  .post(EntryValidatorMiddleware.create, EntryController.createEntry)
   .get(EntryController.getAllEntry);
 router.param('id', idhandler);
 router
   .route('/:id')
-  .patch(EntryController.updateEntry)
+  .patch(EntryValidatorMiddleware.update, EntryController.updateEntry)
   .delete(EntryController.deleteEntry)
   .get(EntryController.getAnEntry);
 router

--- a/Server/tests/entry.test.js
+++ b/Server/tests/entry.test.js
@@ -179,6 +179,21 @@ describe('entry endpoints testing', () => {
           done();
         });
     });
+    it('it should not modify an entry with not data given', (done) => {
+      const modify = {
+      };
+      chai.request(app)
+        .patch('/api/v1/entries/1')
+        .set('token', `Bearer ${token}`)
+        .send(modify)
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.body).to.have.property('message');
+          expect(res.body).to.have.property('status');
+          expect(res.body).to.not.have.property('data');         
+          done();
+        });
+    });
     it('it should not modify an entry with invalid request', (done) => {
       const modify = {
         title: 're',


### PR DESCRIPTION
#### What does this PR do?
this `pr` modifies the validation error message to a better format
#### Description of Task to be completed?
- added validation middleware for entry
- modified the error message
- tested the empty patch request object
#### How should this be manually tested?
- clone this repo
- run `npm install`
- run `npm run dev`
- signup up in the app with invalid data
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#169491641
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A