### PR TITLE
#169494154 correct the slug route name

### DIFF
--- a/Server/routes/entryRoute.js
+++ b/Server/routes/entryRoute.js
@@ -18,7 +18,7 @@ router
   .delete(EntryController.deleteEntry)
   .get(EntryController.getAnEntry);
 router
-  .route('/title/:slug')
+  .route('/slug/:slug')
   .get(EntryController.getBySlug);
 
 export default router;

--- a/Server/routes/entryRoute.js
+++ b/Server/routes/entryRoute.js
@@ -17,6 +17,7 @@ router
   .patch(EntryValidatorMiddleware.update, EntryController.updateEntry)
   .delete(EntryController.deleteEntry)
   .get(EntryController.getAnEntry);
+  
 router
   .route('/slug/:slug')
   .get(EntryController.getBySlug);

--- a/Server/tests/entry.test.js
+++ b/Server/tests/entry.test.js
@@ -280,7 +280,7 @@ describe('entry endpoints testing', () => {
     it('should get an entry when a title slug is given', (done) => {
       chai
         .request(app)
-        .get(`/api/v1/entries/title/${slug}`)
+        .get(`/api/v1/entries/slug/${slug}`)
         .set('token', `Bearer ${token}`)
         .end((err, res) => {
           expect(res.status).to.equal(200);
@@ -294,12 +294,14 @@ describe('entry endpoints testing', () => {
         });
     });
     it('should get an entry when a title slug is given', (done) => {
+      const noSlug = 'day-dfewdes';
       chai
         .request(app)
-        .get('/api/v1/entries/title/day-dfewdes')
+        .get(`/api/v1/entries/slug/${noSlug}`)
         .set('token', `Bearer ${token}`)
         .end((err, res) => {
           expect(res.status).to.equal(404);
+          expect(res.body.message).to.deep.equal(`entry with slug equal to ${noSlug}. not found`);
           done();
         });
     });


### PR DESCRIPTION
#### What does this PR do?
this `pr` changes the name of the slug route from /title to /slug
#### Description of Task to be completed?
- changed the slug route to /slug
- updated the slug route test
#### How should this be manually tested?
- clone this repo
- run `npm install`
- run `npm run dev`
- sign up
- create a entry
- get the entry through the slug route
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#169494154
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A