### PR TITLE
#169634700 user will get the first page when making a get all entry endpoint

### DIFF
--- a/Server/controllers/entryController.js
+++ b/Server/controllers/entryController.js
@@ -60,20 +60,19 @@ export default class EntryController {
         send.error(404, new Error('your diary is empty, no entries found'));
         return send.send(res);
       }
-      if (p) {
-        if (p * 1 < 1 || Number.isNaN(p * 1)) {
-          send.error(400, new Error('a page should be a number and should be greater than 0'));
-          return send.send(res);
-        }
-        const result = paginate(userEntries, p * 1);
-        if (result.entries.length < 1) {
-          send.error(404, new Error(`page ${p} not found`));
-          return send.send(res);
-        }
-        send.successful(200, `page ${p}`, result);
+      const num = p || '1';
+      const regex = /^\d+$/;
+      const truth = regex.test(num);
+      if (!truth) {
+        send.error(400, new Error('a page should be a number and should be greater than 0'));
         return send.send(res);
       }
-      send.successful(200, null, userEntries);
+      const result = paginate(userEntries, num * 1);
+      if (result.entries.length < 1) {
+        send.error(404, new Error(`page ${p} not found`));
+        return send.send(res);
+      }
+      send.successful(200, `page ${num}`, result);
       return send.send(res);
     } catch (error) {
       send.successful(500, error);

--- a/Server/tests/entry.test.js
+++ b/Server/tests/entry.test.js
@@ -267,8 +267,13 @@ describe('entry endpoints testing', () => {
         .set('token', `Bearer ${token}`)
         .end((err, res) => {
           expect(res.status).to.equal(200);
-          expect(res.body.data).to.be.an('array');
-          expect(res.body.data.length).to.equal(2);
+          expect(res.body.data).to.be.an('object');
+          expect(res.body.data.page).to.deep.equal(1);
+          expect(res.body.data.numberOfPages).to.deep.equal(1);
+          expect(res.body.data.entriesOnPage).to.deep.equal(2);
+          expect(res.body.data.totalEntries).to.deep.equal(2);
+          expect(res.body.data.entries).to.be.an('array');
+          expect(res.body.data.entries.length).to.deep.equal(2);
           done();
         });
     });


### PR DESCRIPTION
#### What does this PR do?
this `pr` makes sure that the user get entries on the first page when  the user doesn't specify the page
#### Description of Task to be completed?
- changed the get all endpoint logic to reflect user getting the first page by default
- changed the entry test
#### How should this be manually tested?
N/A
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#169634700
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A